### PR TITLE
Added a link to 'farmOS'  in the README.md section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ FarmData2 is both a _second_ edition of it predecessor, FarmData, and the integr
 
 ### Acknowledgements ###
 
-FarmData2 is powered by the farmOS open source project.
+FarmData2 is powered by the [farmOS](https://farmos.org/) open source project.
 
 Support and assistance with FarmData2 development has been received from [The Non-Profit FOSS Institute](https://npfi.org/).
 


### PR DESCRIPTION
Closes #39, I have added a link to "farmOS" in the readme file with the following syntax

[farmOS](insert link here)

The link would lead to https://not.the.right.link2/, which should be the correct link. Attached is a screenshot to where the link leads.
<img width="1365" height="721" alt="link to website" src="https://github.com/user-attachments/assets/e2685751-0bdc-4edf-9300-8282c0191518" />

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
